### PR TITLE
Encode uri path parts as UTF8 to avoid issues with Unicode playlist names

### DIFF
--- a/mopidy_vkontakte/library.py
+++ b/mopidy_vkontakte/library.py
@@ -98,4 +98,5 @@ class VKLibraryProvider(backend.LibraryProvider):
             return self.backend.session.call_api('audio.get')
 
     def generate_uri(self, path):
-        return 'vkontakte:directory:%s' % urllib.quote('/'.join(path))
+        path_utf8 = [x.encode('utf8') for x in path]
+        return 'vkontakte:directory:%s' % urllib.quote('/'.join(path_utf8))


### PR DESCRIPTION
mopidy-vkontakte crashes on start when the user has playlists with a Unicode (e.g. Cyrillic) names.

Example stacktrace: http://pastebin.com/ded0mNrb

The reason is that urllib does not support Unicode symbols. See http://stackoverflow.com/questions/5557849/is-there-a-unicode-ready-substitute-i-can-use-for-urllib-quote-and-urllib-unquot for more context.
